### PR TITLE
Remove unnecessary underscore dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
-var _ = require('underscore');
-
 module.exports = function (schema, options) {
     var mongoose = options.mongoose;
-    _.each(schema.paths, function (schemaType, path) {
+    schema.eachPath(function (path, schemaType) {
         if (schemaTypeHasUniqueIndex(schemaType)) {
             var validator = buildUniqueValidator(path, mongoose);
             schemaType.validate(validator, 'unique');

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
         "type": "git",
         "url": "https://github.com/blakehaswell/mongoose-unique-validator.git"
     },
-    "dependencies": {
-        "underscore": "1.5.1"
-    },
     "devDependencies": {
         "jasmine-node": "1.10.2",
         "mongoose": "3.6.x"


### PR DESCRIPTION
Only using underscore for the `each()` method, so underscore is overkill for this. Let’s simplify. :sunglasses:
