### PR TITLE
Fix for saving existing model without validation errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,10 @@ function buildUniqueValidator(path, mongoose) {
 
 function buildQuery(field, value, id) {
     var query = { $and: [] };
+    var target = {};
+    target[field] = value;
     query.$and.push({ _id: { $ne: id } });
-    query.$and.push({ field: value });
+    query.$and.push(target);
     return query;
 }
 


### PR DESCRIPTION
This commit will resolve pull request #2.

I passed an id value of the object being validated to buildQuery(), and used that to build a query that excludes the current object being validated from results:

```
{ $and: [ { _id: { $ne: id } }, { field: value } ] }
```

All tests pass.
