### PR TITLE
Support custom error type / kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ user.save(function (err) {
             message: 'Validator failed for path `username` with value `JohnSmith`',
             name: 'ValidatorError',
             path: 'username',
-            type: 'user defined',
+            kind: 'unique',
             value: 'JohnSmith'
         }
     }
@@ -85,3 +85,28 @@ You have access to all of the standard Mongoose error message templating:
 *   `{PATH}`
 *   `{VALUE}`
 *   `{TYPE}`
+
+Custom Error Type
+---------------------
+
+You can pass through a custom error type as part of the optional `options` argument:
+
+```js
+userSchema.plugin(uniqueValidator,  { message: 'Error, expected {PATH} to be {TYPE}.', type: 'distinct' });
+```
+
+```js
+{
+    message: 'Validation failed',
+    name: 'ValidationError',
+    errors: {
+        username: {
+            message: 'Error, expected username to be distinct.',
+            name: 'ValidatorError',
+            path: 'username',
+            kind: 'distinct',
+            value: 'JohnSmith'
+        }
+    }
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 module.exports = function (schema, options) {
-    var message = 'Error, expected `{PATH}` to be unique. Value: `{VALUE}`';
-    if (options && options.message) {
-        message = options.message;
-    }
+    options = options || {};
+    var message = options.message || 'Error, expected `{PATH}` to be unique. Value: `{VALUE}`';
+    var type = options.type || options.kind || 'unique';
     schema.eachPath(function (path, schemaType) {
         if (schemaTypeHasUniqueIndex(schemaType)) {
             var validator = buildUniqueValidator(path);
             message = buildMessage(schemaType.options.unique, message);
-            schemaType.validate(validator, message);
+            schemaType.validate(validator, { message: message, type: type });
         }
     });
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     },
     "devDependencies": {
         "jasmine-node": "1.14.x",
-        "mongoose": "3.8.x"
+        "mongoose": "4.0.x"
     }
 }


### PR DESCRIPTION
* Bump mongoose version to 4.0.x
* Set the default error type / kind of ValidatorError to 'unique'
* Allow the error type / kind to be customized.