### PR TITLE
Add case Insensitive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,17 @@ You have access to all of the standard Mongoose error message templating:
 *   `{PATH}`
 *   `{VALUE}`
 *   `{TYPE}`
+
+
+Case Insensitive
+---------------------
+
+You can add `uniqueCaseInsensitive` option to the key. Then `john.smith@gmail.com` and `John.Smith@gmail.com` will be treated as duplicates.
+
+```js
+var userSchema = mongoose.Schema({
+    username: { type: String, required: true, unique: true },
+    email: { type: String, index: true, unique: true, required: true, uniqueCaseInsensitive: true },
+    password: { type: String, required: true }
+});
+```

--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ module.exports = function(schema, options) {
                         var conditions = [];
                         paths.forEach(function(name) {
                             var condition = {};
-                            condition[name] = doc[name];
+                            if (path.options && path.options.uniqueCaseInsensitive) {
+                                condition[name] = new RegExp('^' + doc[name] + '$', 'i');
+                            } else {
+                                condition[name] = doc[name];
+                            }
+
                             conditions.push(condition);
                         });
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -37,6 +37,24 @@ module.exports = {
         });
     },
 
+    createUserCaseInsensitiveSchema: function() {
+        return new mongoose.Schema({
+            username: {
+                type: String,
+                unique: true
+            },
+            email: {
+                type: String,
+                index: true,
+                unique: true,
+                uniqueCaseInsensitive: true
+            },
+            password: {
+                type: String
+            }
+        });
+    },
+
     createCustomUserSchema: function() {
         return new mongoose.Schema({
             username: {

--- a/test/tests/validation.spec.js
+++ b/test/tests/validation.spec.js
@@ -170,5 +170,26 @@ module.exports = function(mongoose) {
             });
             promise.catch(done);
         });
+
+        it('throws error for single index violation (case insensitive)', function(done) {
+            var User = mongoose.model('User', helpers.createUserCaseInsensitiveSchema().plugin(uniqueValidator));
+
+            // Save the first user
+            var promise = new User(helpers.USERS[0]).save();
+            promise.then(function() {
+                var user = new User(helpers.USERS[0]);
+                user.email = user.email.toUpperCase();
+
+                // Try saving a duplicate
+                user.save().catch(function(err) {
+                    expect(err.errors.email.message).to.equal('Error, expected `email` to be unique. Value: `JOHN.SMITH@GMAIL.COM`');
+                    expect(err.errors.email.properties.type).to.equal('user defined');
+                    expect(err.errors.email.properties.path).to.equal('email');
+
+                    done();
+                });
+            });
+            promise.catch(done);
+        });
     });
 };


### PR DESCRIPTION
Hello there!

So, I improved case insensitive mode a little. Now it's an `uniqueCaseInsensitive` option to the key (so we can have one field with case insensitive mode and other default).

```
var userSchema = mongoose.Schema({
    username: { type: String, required: true, unique: true },
    email: { type: String, index: true, unique: true, required: true, uniqueCaseInsensitive: true },
    password: { type: String, required: true }
});
```

In that case `john.smith@gmail.com` and `John.Smith@gmail.com` will be treated as duplicates.

Thank you!