### PR TITLE
Bug with case insensitive strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var each = require('lodash.foreach');
 var get = require('lodash.get');
+var escapeRegExp = require('lodash.escaperegexp');
 
 var deepPath = function(schema, pathName) {
     var path;
@@ -70,6 +71,9 @@ module.exports = function(schema, options) {
 
                             // Wrap with case-insensitivity
                             if (path.options && path.options.uniqueCaseInsensitive) {
+                                // Excaping some symbols to make sure that some
+                                // symbols will not be interpretated as regExp expression
+                                pathValue = escapeRegExp(pathValue);
                                 pathValue = new RegExp('^' + pathValue + '$', 'i');
                             }
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mongoose": "^4.2.8"
   },
   "dependencies": {
+    "lodash.escaperegexp": "^4.1.1",
     "lodash.foreach": "^4.1.0",
     "lodash.get": "^4.0.2"
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -216,5 +216,8 @@ module.exports = {
     }, {
         email: 'john.smith2000@gmail.com',
         username: 'JohnSmith'
+    }, {
+        email: 'john.smith+1@gmail.com', // valid email alias
+        username: 'JohnSmithAlias'
     }]
 };

--- a/test/tests/validation.spec.js
+++ b/test/tests/validation.spec.js
@@ -357,5 +357,22 @@ module.exports = function(mongoose) {
             });
             promise.catch(done);
         });
+
+        it('throws error for string with regExp like symbols', function(done) {
+            var User = mongoose.model('User', helpers.createUserCaseInsensitiveSchema().plugin(uniqueValidator));
+
+            // Save the first user
+            // Users email contains regExp like symbol "+"
+            var promise = new User(helpers.USERS[6]).save();
+            promise.then(function() {
+                // Try saving a duplicate
+                new User(helpers.USERS[6]).save().catch(function(err) {
+                    expect(err.errors.email.message).to.equal('Error, expected `email` to be unique. Value: `john.smith+1@gmail.com`');
+
+                    done();
+                });
+            });
+            promise.catch(done);
+        });
     });
 };


### PR DESCRIPTION
For checking case insensitive string in packege used [regExp](https://github.com/blakehaswell/mongoose-unique-validator/blob/master/index.js#L73):
```js
pathValue = new RegExp('^' + pathValue + '$', 'i');
```
To avoid problem when string can contain rexExp mutual and find wrong values in DB you should escape this symbols.
I've used node package `lodash.escaperegexp` to escape symbols.

Also, created test "throws error for string with regExp like symbols" that works well.