### PR TITLE
Additional option — type

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ user.save(function (err) {
             message: 'Validator failed for path `username` with value `JohnSmith`',
             name: 'ValidatorError',
             path: 'username',
-            type: 'user defined',
+            type: 'unique',
             value: 'JohnSmith'
         }
     }
@@ -93,6 +93,33 @@ User.findOneAndUpdate(
         // ...
     }
 )
+```
+
+Custom Error Types
+------------------
+
+You can pass through a custom error type as part of the optional `options` argument:
+
+```js
+userSchema.plugin(uniqueValidator, { type: 'mongoose-unique-validator' });
+```
+
+After running the above example the output will be:
+
+```js
+{
+    message: 'Validation failed',
+    name: 'ValidationError',
+    errors: {
+        username: {
+            message: 'Validator failed for path `username` with value `JohnSmith`',
+            name: 'ValidatorError',
+            path: 'username',
+            type: 'mongoose-unique-validator',
+            value: 'JohnSmith'
+        }
+    }
+}
 ```
 
 Custom Error Messages

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ var deepPath = function(schema, pathName) {
 // Export the mongoose plugin
 module.exports = function(schema, options) {
     options = options || {};
+    var type = options.type || 'unique';
     var message = options.message || 'Error, expected `{PATH}` to be unique. Value: `{VALUE}`';
 
     // Dynamically iterate all indexes
@@ -107,7 +108,7 @@ module.exports = function(schema, options) {
                         model.where({ $and: conditions }).count(function(err, count) {
                             respond(count === 0);
                         });
-                    }, pathMessage);
+                    }, pathMessage, type);
                 }
             });
         }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,15 +8,16 @@ module.exports = {
         var collections = Object.keys(mongoose.connection.collections);
         var l = collections.length;
         collections.forEach(function(coll) {
-            mongoose.connection.collections[coll].remove();
-            l--;
+            mongoose.connection.collections[coll].remove(function() {
+                l--;
 
-            if (!l) {
-                mongoose.models = {};
-                mongoose.modelSchemas = {};
-                mongoose.connection.models = {};
-                done();
-            }
+                if (!l) {
+                    mongoose.models = {};
+                    mongoose.modelSchemas = {};
+                    mongoose.connection.models = {};
+                    done();
+                }
+            });
         });
     },
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -11,6 +11,7 @@ mongoose.connection.on('error', function() {
 
 describe('Mongoose Unique Validator', function() {
     require('./tests/validation.spec')(mongoose);
+    require('./tests/types.spec.js')(mongoose);
     require('./tests/messages.spec')(mongoose);
 
     after(function() {

--- a/test/tests/messages.spec.js
+++ b/test/tests/messages.spec.js
@@ -33,8 +33,8 @@ module.exports = function(mongoose) {
             promise.then(function() {
                 // Try saving a duplicate
                 new User(helpers.USERS[0]).save().catch(function(err) {
-                    expect(err.errors.username.message).to.equal('Path: username, value: JohnSmith, type: user defined');
-                    expect(err.errors.email.message).to.equal('Path: email, value: john.smith@gmail.com, type: user defined');
+                    expect(err.errors.username.message).to.equal('Path: username, value: JohnSmith, type: unique');
+                    expect(err.errors.email.message).to.equal('Path: email, value: john.smith@gmail.com, type: unique');
 
                     done();
                 });

--- a/test/tests/types.spec.js
+++ b/test/tests/types.spec.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var helpers = require('../helpers');
+var expect = require('chai').expect;
+var uniqueValidator = require('../../index.js');
+
+module.exports = function(mongoose) {
+    describe('Types', function() {
+        afterEach(helpers.afterEach);
+
+        it('uses default validation type', function(done) {
+            var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
+
+            // Save the first user
+            var promise = new User(helpers.USERS[0]).save();
+            promise.then(function() {
+                // Try saving a duplicate
+                new User(helpers.USERS[0]).save().catch(function(err) {
+                    expect(err.errors.username.kind).to.equal('unique');
+                    done();
+                });
+            });
+            promise.catch(done);
+        });
+
+        it('uses custom type via options', function(done) {
+            var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator, {
+                type: 'mongoose-unique-validator'
+            }));
+
+            // Save the first user
+            var promise = new User(helpers.USERS[0]).save();
+            promise.then(function() {
+                // Try saving a duplicate
+                new User(helpers.USERS[0]).save().catch(function(err) {
+                    expect(err.errors.username.kind).to.equal('mongoose-unique-validator');
+                    expect(err.errors.email.kind).to.equal('mongoose-unique-validator');
+
+                    done();
+                });
+            });
+            promise.catch(done);
+        });
+    });
+};

--- a/test/tests/validation.spec.js
+++ b/test/tests/validation.spec.js
@@ -31,11 +31,11 @@ module.exports = function(mongoose) {
                 // Try saving a duplicate
                 new User(helpers.USERS[0]).save().catch(function(err) {
                     expect(err.errors.username.message).to.equal('Error, expected `username` to be unique. Value: `JohnSmith`');
-                    expect(err.errors.username.properties.type).to.equal('user defined');
+                    expect(err.errors.username.properties.type).to.equal('unique');
                     expect(err.errors.username.properties.path).to.equal('username');
 
                     expect(err.errors.email.message).to.equal('Error, expected `email` to be unique. Value: `john.smith@gmail.com`');
-                    expect(err.errors.email.properties.type).to.equal('user defined');
+                    expect(err.errors.email.properties.type).to.equal('unique');
                     expect(err.errors.email.properties.path).to.equal('email');
 
                     done();
@@ -268,7 +268,7 @@ module.exports = function(mongoose) {
                 // Try saving a duplicate
                 user.save().catch(function(err) {
                     expect(err.errors.email.message).to.equal('Error, expected `email` to be unique. Value: `JOHN.SMITH@GMAIL.COM`');
-                    expect(err.errors.email.properties.type).to.equal('user defined');
+                    expect(err.errors.email.properties.type).to.equal('unique');
                     expect(err.errors.email.properties.path).to.equal('email');
 
                     done();


### PR DESCRIPTION
At first, resolved issue with tests: callback was called before instances were actually removed. Second, added `type` option (default value is `"unique"`), it overrides `kind` property of validation error object and property `type` of error message.