### PR TITLE
Consider $set in doc when validating findOneAndUpdate method and query context

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = function(schema, options) {
 
                             // If the doc is a query, this is a findAndUpdate
                             if (isQuery) {
-                                pathValue = get(doc, '_update.' + name);
+                                pathValue = get(doc, '_update.' + name) || get(doc, '_update.$set.' + name);
                             } else {
                                 pathValue = get(doc, isSubdocument ? name.split('.').pop() : name);
                             }

--- a/test/tests/validation.spec.js
+++ b/test/tests/validation.spec.js
@@ -174,6 +174,32 @@ module.exports = function(mongoose) {
             promise.catch(done);
         });
 
+        it('throws error when saving self with new duplicate value via findOneAndUpdate using $set', function(done) {
+            var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
+
+            var promise = new User(helpers.USERS[0]).save();
+            promise.then(function() {
+                var user = new User(helpers.USERS[1]);
+                user.save().catch(done).then(function() {
+                    User.findOneAndUpdate(
+                        { email: helpers.USERS[0].email },
+                        {
+                            $set: {
+                                email: helpers.USERS[1].email
+                            }
+                        },
+                        { runValidators: true, context: 'query' }
+                    ).exec().catch(function(err) {
+                        expect(err).is.not.null;
+                        expect(err.message).to.equal('Validation failed');
+
+                        done();
+                    });
+                });
+            });
+            promise.catch(done);
+        });
+
         it('throws error when validating self with new duplicate value', function(done) {
             var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
 


### PR DESCRIPTION
Hi,

The validator doesn't work when using findOneAndUpdate (even with context; 'query' parameter) and using $set in doc content.

This pull request solve the issue :)

I hope you could consider this as soon as possible.
Thanks by advance