### PR TITLE
Fix shadow bug with findOneAndUpdate()

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = function(schema, options) {
                         if (!isNew) {
                             // Use conditions the user has with find*AndUpdate
                             if (isQuery) {
-                                each(doc._conditions, function(value, key) {
+                                each(doc._conditions, function(val, key) {
                                     var cond = {};
                                     cond[key] = { $ne: value };
                                     conditions.push(cond);


### PR DESCRIPTION
Hello! 

Spend a good part of today trying to figure out why this plugin didn't work and I ended stepping through the entire plugin. Because the variables used for lodash's `each` are `value, key`, value overwrites the upper scope's actual `value` to undefined. So when the query is actually made, the count is always 0 because it's looking for an `email` (or other unique field) that is set to `undefined`