### PR TITLE
changed .count to .countDocuments. Because .count is deprecated and w…

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ module.exports = function(schema, options) {
                                 model = this.model(this.constructor.modelName);
                             }
 
-                            model.where({ $and: conditions }).count((err, count) => {
+                            model.where({ $and: conditions }).countDocuments((err, count) => {
                                 resolve(count === 0);
                             });
                         });


### PR DESCRIPTION
…ill be removed in future versions. And it's raising flags when being used.
Changes have passed eslint & all test cases.