### PR TITLE
fixed issue where unique wouldn't work on discriminator models if `unique` set on the base model

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,12 @@ module.exports = function(schema, options) {
                             } else if (isFunc(this.model)) {
                                 model = this.model(this.constructor.modelName);
                             }
+                            // Is this model a discriminator and the unique index is on the whole collection,
+                            // not just the instances of the discriminator? If so, use the base model to query.
+                            // https://github.com/Automattic/mongoose/issues/4965
+                            if (model.baseModelName && indexOptions.partialFilterExpression == null) {
+                              model = model.db.model(model.baseModelName);
+                            }
 
                             model.where({ $and: conditions }).countDocuments((err, count) => {
                                 resolve(count === 0);


### PR DESCRIPTION
Hi,

Re: https://github.com/Automattic/mongoose/issues/4965, I found a small issue with mongoose-unique-validator and mongoose discriminators even if [the `applyPluginsToDiscriminators` option](http://mongoosejs.com/docs/api.html#mongoose_Mongoose-set) is set. If `unique` is declared on the base model, you still may get an E11000 from MongoDB when saving an instance of the discriminator model because mongoose-unique-validator will use the discriminator model, not the base model. Below is an example

```javascript
const mongoose = require('mongoose');
mongoose.set('debug', true);

const muv = require('mongoose-unique-validator');
const {Schema} = mongoose;
mongoose.set('applyPluginsToDiscriminators', true);
mongoose.connect('mongodb://localhost:27017/test');
mongoose.plugin(muv);

const test = new Schema({
  a: {
    type:Number,
    unique:true
  }
});
const test2 = new Schema({
  b:String,
});
const Test = mongoose.model('Test',test);
const Test2 = Test.discriminator('Test2',test2);

main().catch(error => console.error(error.stack));

async function main() {
  await mongoose.connection.dropDatabase();

  await Test.create([{ a: 1 }]);
  await Test2.create([{ a: 1 }]); // E11000
}
```

Please let me know if you need me to do anything else re: this issue :+1: