### PR TITLE
Escape RegExp chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,8 @@ module.exports = function(schema, options) {
 
                                 // Wrap with case-insensitivity
                                 if (get(path, 'options.uniqueCaseInsensitive') || indexOptions.uniqueCaseInsensitive) {
+                                    // Escapse RegExp chars
+                                    pathValue = pathValue.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
                                     pathValue = new RegExp('^' + pathValue + '$', 'i');
                                 }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -232,5 +232,15 @@ module.exports = {
     }, {
         email: 'john.smith2000@gmail.com',
         username: 'JohnSmith'
+    }],
+
+    USERS_REGEX: [{
+        username: 'JohnSmith0',
+        email: 'john0smith@gmail.com',
+        password: 'j0hnNYb0i0'
+    }, {
+        username: 'JohnSmith',
+        email: 'john.smith@gmail.com',
+        password: 'j0hnNYb0i'
     }]
 };

--- a/test/tests/validation.spec.js
+++ b/test/tests/validation.spec.js
@@ -22,6 +22,21 @@ module.exports = function(mongoose) {
             promise.catch(done);
         });
 
+        it('allow unique records with regex wildcards', function(done) {
+            var User = mongoose.model('User', helpers.createUserCaseInsensitiveSchema().plugin(uniqueValidator));
+
+            // Save the first user
+            var promise = new User(helpers.USERS_REGEX[0]).save();
+            promise.then(function() {
+                // Try saving a unique user with email that has a regex wildcard
+                new User(helpers.USERS_REGEX[1]).save().catch(done).then(function(res) {
+                    expect(res.email).to.equal(helpers.USERS_REGEX[1].email);
+                    done();
+                });
+            });
+            promise.catch(done);
+        });
+
         it('throws error for single index violation', function(done) {
             var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
 


### PR DESCRIPTION
Add RegExp escape to avoid false positives.
For example, if we have the email `john2smith@gmail.com` in our DB, and then we try to add the email `john.smith@gmail.com`, then the validation will fail, because the dot in the second email is considered as a wild card, and thus finds the first email.
After the escaping, the new email will be checked as `john\.smith@gmail.com`