### PR TITLE
Default custom error messages and type

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ After running the above example the output will be:
 }
 ```
 
+You can also specify a default custom error type by overriding the plugin `defaults.type` variable:
+
+```js
+uniqueValidator.defaults.type = 'mongoose-unique-validator'
+```
+
 Custom Error Messages
 ---------------------
 
@@ -136,6 +142,12 @@ You have access to all of the standard Mongoose error message templating:
 *   `{PATH}`
 *   `{VALUE}`
 *   `{TYPE}`
+
+You can also specify a default custom error message by overriding the plugin `defaults.message` variable:
+
+```js
+uniqueValidator.defaults.message = 'Error, expected {PATH} to be unique.'
+```
 
 
 Case Insensitive

--- a/index.js
+++ b/index.js
@@ -25,11 +25,10 @@ const deepPath = function(schema, pathName) {
     return path;
 };
 
-// Export the mongoose plugin
-module.exports = function(schema, options) {
+const plugin = function(schema, options) {
     options = options || {};
-    const type = options.type || 'unique';
-    const message = options.message || 'Error, expected `{PATH}` to be unique. Value: `{VALUE}`';
+    const type = options.type || plugin.defaults.type || 'unique';
+    const message = options.message || plugin.defaults.message || 'Error, expected `{PATH}` to be unique. Value: `{VALUE}`';
 
     // Mongoose Schema objects don't describe default _id indexes
     // https://github.com/Automattic/mongoose/issues/5998
@@ -118,3 +117,9 @@ module.exports = function(schema, options) {
         }
     });
 };
+
+plugin.defaults = {
+};
+
+// Export the mongoose plugin
+module.exports = plugin;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var mongoose = require('mongoose');
+var uniqueValidator = require('../index.js');
 
 // Helper methods/objects for tests
 module.exports = {
@@ -19,6 +20,7 @@ module.exports = {
                 }
             });
         });
+        uniqueValidator.defaults = {};
     },
 
     createUserSchema: function() {

--- a/test/tests/messages.spec.js
+++ b/test/tests/messages.spec.js
@@ -58,5 +58,23 @@ module.exports = function(mongoose) {
             });
             promise.catch(done);
         });
+
+        it('uses custom message from default plugin configuration', function(done) {
+            uniqueValidator.defaults.message = 'Path: {PATH}, value: {VALUE}, type: {TYPE}';
+            var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
+
+            // Save the first user
+            var promise = new User(helpers.USERS[0]).save();
+            promise.then(function() {
+                // Try saving a duplicate
+                new User(helpers.USERS[0]).save().catch(function(err) {
+                    expect(err.errors.username.message).to.equal('Path: username, value: JohnSmith, type: unique');
+                    expect(err.errors.email.message).to.equal('Path: email, value: john.smith@gmail.com, type: unique');
+
+                    done();
+                });
+            });
+            promise.catch(done);
+        });
     });
 };

--- a/test/tests/types.spec.js
+++ b/test/tests/types.spec.js
@@ -41,5 +41,23 @@ module.exports = function(mongoose) {
             });
             promise.catch(done);
         });
+
+        it('uses custom type from default plugin configuration', function(done) {
+            uniqueValidator.defaults.type = 'mongoose-unique-validator';
+            var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
+
+            // Save the first user
+            var promise = new User(helpers.USERS[0]).save();
+            promise.then(function() {
+                // Try saving a duplicate
+                new User(helpers.USERS[0]).save().catch(function(err) {
+                    expect(err.errors.username.kind).to.equal('mongoose-unique-validator');
+                    expect(err.errors.email.kind).to.equal('mongoose-unique-validator');
+
+                    done();
+                });
+            });
+            promise.catch(done);
+        });
     });
 };


### PR DESCRIPTION
Added the ability to specify a plugin wide default error type and error message as mentioned in issue #102 

Updated tests to test this ability as well.