### PR TITLE
Validation will always fail on updates for `_id`

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,11 @@ const plugin = function(schema, options) {
                             const isNew = typeof parentDoc.isNew === 'boolean' ? parentDoc.isNew : !isQuery;
 
                             const conditions = {};
+
+                            if (!isNew && !isQuery && !this.isModified(pathName)) {
+                                return resolve(true);
+                            }
+
                             each(paths, (name) => {
                                 let pathValue;
 

--- a/test/tests/validation.spec.js
+++ b/test/tests/validation.spec.js
@@ -133,6 +133,45 @@ module.exports = function(mongoose) {
             promise.catch(done);
         });
 
+        it('does not throw error when saving self with new unique value via findByIdAndUpdate', function(done) {
+            var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
+
+            var user = new User(helpers.USERS[0]);
+
+            // Save a user
+            var promise = user.save();
+            promise.then(function() {
+                User.findByIdAndUpdate(
+                    user._id,
+                    { email: 'somethingNew@example.com', username: 'JohnSmith' },
+                    { runValidators: true, context: 'query' }
+                ).exec().catch(done).then(function(result) {
+                    expect(result).to.be.an('object');
+                    done();
+                });
+            });
+            promise.catch(done);
+        });
+
+        // adresses https://github.com/blakehaswell/mongoose-unique-validator/issues/108
+        it('does not throw error when saving self with new unique value via findByIdAndUpdate with multiple records', function(done) {
+            var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
+
+            // Save a user
+            var promise = User.insertMany([helpers.USERS[0], helpers.USERS[1]]);;
+            promise.then(function(createdUsers) {
+                User.findByIdAndUpdate(
+                    createdUsers[0]._id,
+                    { email: 'somethingNew@example.com', username: 'JohnSmith' },
+                    { runValidators: true, context: 'query' }
+                ).exec().catch(done).then(function(result) {
+                    expect(result).to.be.an('object');
+                    done();
+                });
+            });
+            promise.catch(done);
+        });
+
         it('does not throw error when saving self with new unique value via findById', function(done) {
             var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
 
@@ -142,6 +181,25 @@ module.exports = function(mongoose) {
             var promise = user.save();
             promise.then(function() {
                 User.findById(user._id).then(function(foundUser) {
+                    foundUser.email = 'somethingNew@example.com';
+                    foundUser.username = 'JohnSmith';
+                    foundUser.save().then(function(result) {
+                        expect(result).to.be.an('object');
+                        done();
+                    }).catch(done);
+                });
+            });
+            promise.catch(done);
+        });
+
+        // adresses https://github.com/blakehaswell/mongoose-unique-validator/issues/108
+        it('does not throw error when saving self with new unique value via findById with multiple records', function(done) {
+            var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
+
+            // Save a user
+            var promise = User.insertMany([helpers.USERS[0], helpers.USERS[1]]);
+            promise.then(function(createdUsers) {
+                User.findById(createdUsers[0]._id).then(function(foundUser) {
                     foundUser.email = 'somethingNew@example.com';
                     foundUser.username = 'JohnSmith';
                     foundUser.save().then(function(result) {
@@ -183,6 +241,30 @@ module.exports = function(mongoose) {
                 user.save().catch(done).then(function() {
                     User.findOneAndUpdate(
                         { email: helpers.USERS[0].email },
+                        { email: helpers.USERS[1].email },
+                        { runValidators: true, context: 'query' }
+                    ).exec().catch(function(err) {
+                        expect(err.errors.email.name).to.equal('ValidatorError');
+                        expect(err.errors.email.kind).to.equal('unique');
+                        expect(err.errors.email.path).to.equal('email');
+                        expect(err.errors.email.value).to.equal('bob@robertmiller.com');
+
+                        done();
+                    });
+                });
+            });
+            promise.catch(done);
+        });
+
+        it('throws error when saving self with new duplicate value via findByIdAndUpdate', function(done) {
+            var User = mongoose.model('User', helpers.createUserSchema().plugin(uniqueValidator));
+
+            var promise = new User(helpers.USERS[0]).save();
+            promise.then(function(createdUser) {
+                var user = new User(helpers.USERS[1]);
+                user.save().catch(done).then(function() {
+                    User.findByIdAndUpdate(
+                        createdUser._id,
                         { email: helpers.USERS[1].email },
                         { runValidators: true, context: 'query' }
                     ).exec().catch(function(err) {


### PR DESCRIPTION
I believe this should cover what was discussed in #108.

When using `.save()` for an update, every single `unique` index was being validated against, unlike when using `find*AndUpdate`, only updated paths would be queried against.

I changed it so that only paths that are updated are validated for uniqueness, so `_id` won't be considered updated (as it can't even be without throwing a MongoError), it won't end up being queried against on updates.

Should also come with a bit of a performance boost then, because it isn't needing to query on every single `unique` field, even if they haven't been updated.