### PR TITLE
Changed "=== null" to "== null"

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ const plugin = function(schema, options) {
                             // Is this model a discriminator and the unique index is on the whole collection,
                             // not just the instances of the discriminator? If so, use the base model to query.
                             // https://github.com/Automattic/mongoose/issues/4965
-                            if (model.baseModelName && indexOptions.partialFilterExpression === null) {
+                            if (model.baseModelName && indexOptions.partialFilterExpression == null) {
                                 model = model.db.model(model.baseModelName);
                             }
 


### PR DESCRIPTION
'== null' checks for undefined as well as null. In this situation using "==" is proper as undefined should run line 112