### PR TITLE
Skip check if logic would only look for the _id field

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,9 +112,24 @@ const plugin = function(schema, options) {
                                 model = model.db.model(model.baseModelName);
                             }
 
-                            model.find(conditions).countDocuments((err, count) => {
-                                resolve(count === 0);
-                            });
+                            // Skip, if only the _id field should be checked and it's a command on a existing document.
+                            let skip = false;
+                            if (!isNew && !isQuery) {
+                                const fieldsToCheck = Object.keys(conditions);
+
+                                if (fieldsToCheck.length === 1 && fieldsToCheck[0] === '_id') {
+                                    skip = true;
+                                }
+                            }
+
+                            if (skip) {
+                                resolve(true);
+                            } else {
+                                model.find(conditions).countDocuments((err, count) => {
+                                    resolve(count === 0);
+                                });
+                            }
+
                         });
                     }, pathMessage, type);
                 }


### PR DESCRIPTION
This is related to https://github.com/blakehaswell/mongoose-unique-validator/issues/131

I (think) I figured out why the plugin would complain with `Error, expected `_id` to be unique.` if editing an existing document.
It should IMHO skip the check if only the _id field would be in the condition on a edit. Otherwise what ends up happening is that it only uses the condition `_id: {$ne: [id of doc to edit]}`. The plugin will then (obviously) find all other documents in the collection and assume it found duplicates.

I'm not sure if that's the best way to prevent that as I don't fully understand the ins and outs of the code, but it works great for me.