### PR TITLE
Fix validation for _id field

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,10 @@ const plugin = function(schema, options) {
                             const parentDoc = isSubdocument ? this.ownerDocument() : this;
                             const isNew = typeof parentDoc.isNew === 'boolean' ? parentDoc.isNew : !isQuery;
 
+                            if (!isNew && !isQuery && pathName === '_id' && !this.isModified(pathName)) {
+                                resolve(true);
+                                return;
+                            }
                             const conditions = {};
                             each(paths, (name) => {
                                 let pathValue;
@@ -108,7 +112,7 @@ const plugin = function(schema, options) {
                             // Is this model a discriminator and the unique index is on the whole collection,
                             // not just the instances of the discriminator? If so, use the base model to query.
                             // https://github.com/Automattic/mongoose/issues/4965
-                            if (model.baseModelName && (indexOptions.partialFilterExpression === null || indexOptions.partialFilterExpression === undefined)) {
+                            if (model.baseModelName && indexOptions.partialFilterExpression === null) {
                                 model = model.db.model(model.baseModelName);
                             }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,7 +9,7 @@ module.exports = {
         var collections = Object.keys(mongoose.connection.collections);
         var l = collections.length;
         collections.forEach(function(coll) {
-            mongoose.connection.collections[coll].remove(function() {
+            mongoose.connection.collections[coll].drop(function() {
                 l--;
 
                 if (!l) {


### PR DESCRIPTION
This PR fixes the validation issue when updating a document the issues related are #88 and #108 

The changes do not prevent executing the rest of the validations in other fields