### PR TITLE
bug(118) fix 'where' when model fld exists in data

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,8 @@ const plugin = function(schema, options) {
                                 model = this.ownerDocument().model(this.ownerDocument().constructor.modelName);
                             } else if (isFunc(this.model)) {
                                 model = this.model(this.constructor.modelName);
+                            } else {
+                                model = this.constructor.model(this.constructor.modelName);
                             }
 
                             // Is this model a discriminator and the unique index is on the whole collection,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -195,6 +195,16 @@ module.exports = {
         });
     },
 
+    createUniqueIDSchemaNonStrict: function() {
+        return new mongoose.Schema({
+            uid: {
+                type: 'String',
+                required: true,
+                unique: true
+            }
+        }, { strict: false });
+    },
+
     createArrayOfNestedUserSchema: function() {
         return new mongoose.Schema({
             username: {

--- a/test/tests/validation.spec.js
+++ b/test/tests/validation.spec.js
@@ -499,5 +499,24 @@ module.exports = function(mongoose) {
             });
             promise.catch(done);
         });
+
+        it('does not throw error when create vs save data (with model field)', function(done) {
+            var UID = mongoose.model('UID', helpers.createUniqueIDSchemaNonStrict().plugin(uniqueValidator));
+
+            // Save the first user
+            const payloadWithModelField = {
+                uid: '12345',
+                model: 'some-value'
+            };
+
+            // perform a create() vs save()
+            var promise = UID.create(payloadWithModelField);
+            promise.then(function(res) {
+                expect(res.uid).to.equal(payloadWithModelField.uid);
+                expect(res.model).to.equal(payloadWithModelField.model);
+                done();
+            });
+            promise.catch(done);
+        });
     });
 };


### PR DESCRIPTION
Fixes #118 
- when using `create()` vs `save()` and there is a field called `model` on the payload the `this.model` is the value of the field not a function that gets you the mongoose schema/model
- need another default option if the other checks don't pass to get the model from `this.constructor`