### PR TITLE
fix(types): make plugin function generic to satisfy mongoose PluginFunction constraint

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import type { Schema } from 'mongoose'
+import type { Model, Schema } from 'mongoose'
 
 export interface MongooseUniqueValidatorOptions {
   /** Error type string used in the ValidationError (default: `'unique'`). */
@@ -15,7 +15,24 @@ export interface MongooseUniqueValidatorOptions {
 }
 
 export interface MongooseUniqueValidator {
-  (schema: Schema, options?: MongooseUniqueValidatorOptions): void
+  <
+    DocType,
+    TModelType extends Model<DocType>,
+    TInstanceMethods,
+    TQueryHelpers,
+    TVirtuals,
+    TStaticMethods
+  >(
+    schema: Schema<
+      DocType,
+      TModelType,
+      TInstanceMethods,
+      TQueryHelpers,
+      TVirtuals,
+      TStaticMethods
+    >,
+    options?: MongooseUniqueValidatorOptions
+  ): void
 
   defaults: MongooseUniqueValidatorOptions
 }


### PR DESCRIPTION
The bare Schema type in the plugin call signature was incompatible with
mongoose 8/9's PluginFunction<DocType, TModelType, ...> constraint, which
schema.plugin() enforces when called on a fully-typed schema.

Codebases upgrading from @types/mongoose-unique-validator (which brought
its own mongoose@6 as a transitive dependency, masking the issue) to the
native types in v6 encounter TS2345 errors like:

  Argument of type 'MongooseUniqueValidator' is not assignable to
  parameter of type 'PluginFunction<UserDocument, UserModel, ...>'

The fix mirrors the pattern mongoose recommends for plugin authors: declare
the schema parameter as a generic over all six Schema type parameters so
TypeScript can unify the concrete schema type at the call site without a
type assertion.

As part of updating our real-world repo that used mongoose-unique-validator, this fix was needed.

Co-Authored-By: Oz <oz-agent@warp.dev>
